### PR TITLE
fixed `test_image_pack_url` for latest rails.

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -17,7 +17,7 @@ class HelperTest < ActionView::TestCase
   end
 
   def test_image_pack_url
-    assert_equal '/packs/images/favicon.ico', image_pack_url('favicon.ico')
+    assert_equal 'http://test.host/packs/images/favicon.ico', image_pack_url('favicon.ico')
   end
 
   def test_favicon_pack_tag


### PR DESCRIPTION
It seems that the `asset_url` in the test environment has been changed to include the host since Rails v7.0.3.

```
$ bundle exec rails -v
Rails 7.0.2.4

$ bundle exec rake test

............

Finished in 0.005473s, 2192.5818 runs/s, 2375.2969 assertions/s.
12 runs, 13 assertions, 0 failures, 0 errors, 0 skips

$ bundle exec rails -v
Rails 7.0.3

$ bundle exec rake test

..F

Failure:
HelperTest#test_image_pack_url [simpacker/test/helper_test.rb:20]:
--- expected
+++ actual
@@ -1 +1 @@
-"/packs/images/favicon.ico"
+"http://test.host/packs/images/favicon.ico"
```

I thought asset_url was expected to return a url containing the host, so I fixed the expectation.