### PR TITLE
Add `picture_pack_tag` to helper.

### DIFF
--- a/lib/simpacker/helper.rb
+++ b/lib/simpacker/helper.rb
@@ -30,6 +30,16 @@ module Simpacker
       asset_url(simpacker_context.manifest.lookup!(name), **options)
     end
 
+    def picture_pack_tag(*names, &block)
+      unless Rails.gem_version >= Gem::Version.new('7.1.0')
+        raise NotImplementedError, '`picture_pack_tag` is only available for Rails 7.1 or above.'
+      end
+      names.flatten!
+      options = names.extract_options!
+      sources = names.map { |name| asset_path(simpacker_context.manifest.lookup!(name)) }
+      picture_tag(*sources, options, &block)
+    end
+
     def favicon_pack_tag(name, **options)
       favicon_link_tag(asset_path(simpacker_context.manifest.lookup!(name)), **options)
     end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -20,6 +20,20 @@ class HelperTest < ActionView::TestCase
     assert_equal 'http://test.host/packs/images/favicon.ico', image_pack_url('favicon.ico')
   end
 
+  if Rails.gem_version >= Gem::Version.new('7.1.0')
+    def test_picture_pack_tag
+      assert_equal '<picture><img src="/packs/images/favicon.ico" /></picture>', picture_pack_tag('favicon.ico')
+      assert_equal '<picture><img src="/packs/images/favicon.ico" width="20" height="20" /></picture>', picture_pack_tag('favicon.ico', image: { size: "20" })
+      assert_equal <<~HTML.gsub(/\n\s*/, ''), picture_pack_tag('favicon.ico', 'sample.png', image: { alt: 'Image' })
+        <picture>
+          <source srcset="/packs/images/favicon.ico" />
+          <source srcset="/packs/images/sample.png" type="image/png" />
+          <img alt="Image" src="/packs/images/sample.png" />
+        </picture>
+      HTML
+    end
+  end
+
   def test_favicon_pack_tag
     assert_equal '<link rel="icon" type="image/x-icon" href="/packs/images/favicon.ico" />', favicon_pack_tag('favicon.ico')
   end

--- a/test/test_app/public/packs/manifest.json
+++ b/test/test_app/public/packs/manifest.json
@@ -2,5 +2,6 @@
   "application.css": "/packs/application.css",
   "application.js": "/packs/application.js",
   "application.js.map": "/packs/application.js.map",
-  "favicon.ico": "/packs/images/favicon.ico"
+  "favicon.ico": "/packs/images/favicon.ico",
+  "sample.png": "/packs/images/sample.png"
 }


### PR DESCRIPTION
Added `picture_tag` added in Rails v7.1 .

https://github.com/rails/rails/blob/v7.1.0/actionview/lib/action_view/helpers/asset_tag_helper.rb#L440-L499

Not available in Rails v7.1 or less, so we raise `NotImplementedError`.