### PR TITLE
Updated the version of Ruby being run on CI to the latest state.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["3.1", "3.2", "3.3"]
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
I added the released Ruby v3.2 series and v3.3 series to the version of Ruby being run on CI. Also, the Ruby v3.0 series and v2.7 series have been removed as their EOL.

> Ruby 3.0
> status: eol
> release date: 2020-12-25
> normal maintenance until: 2023-04-01
> EOL: 2024-04-23
>
> Ruby 2.7
> status: eol
> release date: 2019-12-25
> normal maintenance until: 2022-04-01
> EOL: 2023-03-31
>
> https://www.ruby-lang.org/en/downloads/branches/